### PR TITLE
CSS Bug: dark mode margin fix

### DIFF
--- a/src/styled-components/ContributorCard/index.css
+++ b/src/styled-components/ContributorCard/index.css
@@ -38,7 +38,3 @@
    margin: 1% 0;
    
 }
- .card__container:nth-child(3n-1) {
-    margin-left: 2%;
-    margin-right: 2%;
-  }


### PR DESCRIPTION
In this PR, the CSS issue has been fixed for dark mode. 
In dark mode, the middle section(hackoctoberfest-accepted-2022) was smaller than the other two sections.
<img width="1440" alt="Screenshot 2022-10-02 at 6 20 18 PM" src="https://user-images.githubusercontent.com/70550395/193454895-45ab24d4-8407-4675-aada-96f68c69c8ee.png">
