### PR TITLE
Improve responsive view for navbar

### DIFF
--- a/src/components/Header/index.css
+++ b/src/components/Header/index.css
@@ -3,7 +3,6 @@ header{
   align-items: center;
   justify-content: space-between;
   padding: 1rem;
-
   margin-bottom: 1rem;
 }
 .header__dark{

--- a/src/components/Header/index.css
+++ b/src/components/Header/index.css
@@ -3,7 +3,7 @@ header{
   align-items: center;
   justify-content: space-between;
   padding: 1rem;
-  
+
   margin-bottom: 1rem;
 }
 .header__dark{
@@ -45,4 +45,27 @@ header nav{
 
 .brand__container a:hover, .header__nav__list__item a:hover{
   color: var(--cyan-color);
+}
+
+@media (max-width: 767.98px) {
+  header {
+    position: relative;
+    margin-bottom: 45px;
+  }
+
+  .navbar {
+    position: absolute;
+    left: 0;
+    top: 70px;
+    width: 100%;
+    border-bottom: 1px solid #CCC;
+  }
+
+  .navbar a {
+    font-size: 0.9em;
+  }
+
+  .header__nav__list {
+    margin: 0 auto;
+  }
 }

--- a/src/components/Header/index.css
+++ b/src/components/Header/index.css
@@ -55,16 +55,27 @@ header nav{
   .navbar {
     position: absolute;
     left: 0;
-    top: 70px;
+    bottom: -45px;
     width: 100%;
     border-bottom: 1px solid #CCC;
+    overflow: hidden;
+  }
+  .navbar ul {
+    padding: 0;
   }
 
-  .navbar a {
+  .navbar li a {
+    padding: 0 5px;
     font-size: 0.9em;
   }
 
   .header__nav__list {
     margin: 0 auto;
+  }
+}
+
+@media (max-width: 350px) {
+  .navbar li a {
+    font-size: 0.75em;
   }
 }

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -11,7 +11,7 @@ function Header() {
       <div className={mode ? "brand__container" : "brand__container__light"}>
         <Link to="/" className="fw-semibold">Hactoberfest React</Link>
       </div>
-      <nav>
+      <nav className="navbar">
         <ul className="header__nav__list mb-0">
           <li
             className={


### PR DESCRIPTION
Reference to issue: https://github.com/dikshantrajput/hacktoberfest-2022-react/issues/26

Note:
- support for more than 300px screen width
- best solution is secondary nav button with dropdown which is working by [RahulRudra81](https://github.com/RahulRudra81)

Before:
<img width="417" alt="Screen Shot 2565-10-02 at 22 10 33" src="https://user-images.githubusercontent.com/1849256/193461900-d85cfd17-88b8-4725-813e-132a43583861.png">

After:
<img width="416" alt="Screen Shot 2565-10-02 at 22 10 07" src="https://user-images.githubusercontent.com/1849256/193461903-d4c0d0aa-43b1-4494-8ec2-375dc1ade956.png">

