### PR TITLE
Fix primary button and footer links

### DIFF
--- a/src/components/Footer/index.css
+++ b/src/components/Footer/index.css
@@ -1,16 +1,18 @@
-footer{
-  padding: 1rem;
-  margin-top: 1rem;
+footer {
+    padding: 1rem;
+    margin-top: 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-evenly;
 }
-.footer__light{
-  box-shadow: 0px -3px 7px 0px #355764;
-  /* Added Font-Weight */
-  font-weight: 600;
+.footer__light {
+    box-shadow: 0px -3px 7px 0px #355764;
+    /* Added Font-Weight */
+    font-weight: 600;
 }
-.footer__dark{
-  box-shadow: 0px -2px 5px 0px var(--shadow-color);
+.footer__dark {
+    box-shadow: 0px -2px 5px 0px var(--shadow-color);
 }
-a {
-  color: #34c0eb;
-  padding-right: 20px;
+footer a {
+    color: #34c0eb;
 }

--- a/src/styled-components/Buttons/primary/index.css
+++ b/src/styled-components/Buttons/primary/index.css
@@ -1,25 +1,28 @@
 .primary__button {
-  /* background: var(--secondary-color); */
-  background: #002B5B;
-  font-weight: 600;
-  border: 1px solid var(--secondary-color);
-  padding: 0.30rem 0.3rem;
-  border-radius: 4px;
+    /* background: var(--secondary-color); */
+    background: #002b5b;
+    font-weight: 600;
+    border: 1px solid var(--secondary-color);
+    padding: 0.5rem;
+    border-radius: 4px;
+    width: fit-content;
+    max-width: 100%;
+    word-wrap: break-word;
+    margin: 0 auto;
+    font-size: 1.2rem;
 }
 
 .primary__button a {
-  color: var(--white-color);
-  font-size: 1.2rem;
-  margin: 10%;
+    color: var(--white-color);
 }
 
 .primary__button:hover {
-  /* background: var(--cyan-color); */
-  cursor: pointer;
-  transition: all 0.2s;
+    /* background: var(--cyan-color); */
+    cursor: pointer;
+    transition: all 0.2s;
 }
 
 .primary__button:hover a {
-  /* color: var(--black-color); */
-  color: #8FE3CF;
+    /* color: var(--black-color); */
+    color: #8fe3cf;
 }

--- a/src/styled-components/Buttons/primary/index.jsx
+++ b/src/styled-components/Buttons/primary/index.jsx
@@ -1,14 +1,14 @@
-import React from 'react'
-import './index.css'
+import React from "react"
+import "./index.css"
 
-function PrimaryButton({text, link, external = false}) {
-  return (
-    <button className='primary__button'>
-      <a href={link} target={`${external ? '__dk' : ''}`}>
-        {text}
-      </a>
-    </button>
-  )
+function PrimaryButton({ text, link, external = false }) {
+    return (
+        <div className="primary__button">
+            <a href={link} target={`${external ? "__dk" : ""}`}>
+                {text}
+            </a>
+        </div>
+    )
 }
 
 export default PrimaryButton


### PR DESCRIPTION
This PR fixes a few issues I found with the primary button and footer links:

- Specificity wasn't enough for the links in the footer (styles were being applied to all anchor tags), so now this has been improved to target `footer a` elements.
- Improved the centering of the footer links to use `flex` display rather than relying on `padding-right` between each footer link.
- Removed the use of the `button` tag in `PrimaryButton`. It's never a good idea to mix the `button` and `a` tags together as it is not valid HTML. (Buttons cannot have interactive content inside them, such as an `a` tag. see more info [here](https://dev.w3.org/html5/spec-LC/the-button-element.html#the-button-element)). 
- Improved the styles for `PrimaryButton`